### PR TITLE
Append domain name to host name

### DIFF
--- a/hoster.py
+++ b/hoster.py
@@ -62,6 +62,8 @@ def get_container_data(dockerClient, container_id):
     container_hostname = info["Config"]["Hostname"]
     container_name = info["Name"].strip("/")
     container_ip = info["NetworkSettings"]["IPAddress"]
+    if info["Config"]["Domainname"]:
+        container_hostname = container_hostname + "." + info["Config"]["Domainname"]
     
     result = []
 


### PR DESCRIPTION
Currently the domain name part is ignored as docker stores this in the info["Config"]["Domainname"]
This commit fixes that by appending the domain name if it is present