### PR TITLE
Only attempt lines trim if the list isn't empty

### DIFF
--- a/hoster.py
+++ b/hoster.py
@@ -106,7 +106,8 @@ def update_hosts_file():
             break;
 
     #remove all the trailing newlines on the line list
-    while lines[-1].strip()=="": lines.pop()
+    if lines:
+        while lines[-1].strip()=="": lines.pop()
 
     #append all the domain lines
     if len(hosts)>0:


### PR DESCRIPTION
In the event that a hosts file is empty the following line can provide an IndexError:

`while lines[-1].strip()=="": lines.pop()`

This PR will skip this step in the event that the list is empty