### PR TITLE
Extend hoster to get paths from environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-python3
+FROM python:3.10.6-alpine3.16
 
 RUN pip3 install docker
 RUN mkdir /hoster
@@ -6,6 +6,3 @@ WORKDIR /hoster
 ADD hoster.py /hoster/
 
 CMD ["python3", "-u", "hoster.py"]
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # Hoster
 
+## Mount hosts file directyly
 A simple "etc/hosts" file injection tool to resolve names of local Docker containers on the host.
 
 hoster is intended to run in a Docker container:
 
     docker run -d \
-        -v /var/run/docker.sock:/tmp/docker.sock \
-        -v /etc/hosts:/tmp/hosts \
+        --mount type=bind,source=/var/run/docker.sock,target=/tmp/docker.sock \
+        --mount type=bind,source=/etc/hosts,target=/tmp/hosts \
         dvdarias/docker-hoster
+
+## Mount directory containing hosts file
+In some cases there is a problem while rewriting hosts file. This can be prevent with mapping/mounting complete directory and point to the hosts file with environment variable.
+
+    docker run -d \
+        -e HOST_PATH=/tmp/etc/hosts -e SOCK_PATH=tmp/docker.sock \
+        --mount type=bind,source=/etc,target=/tmp/etc \
+        --mount type=bind,source=/var/run/docker.sock,target=/tmp/docker.sock \
+        dvdarias/docker-hoster
+
 
 The `docker.sock` is mounted to allow hoster to listen for Docker events and automatically register containers IP.
 

--- a/hoster.py
+++ b/hoster.py
@@ -129,9 +129,11 @@ def update_hosts_file():
 
 
 def parse_args():
+    hostPath = os.getenv('HOST_PATH', "/tmp/hosts")
+    sockPath = os.getenv('SOCK_PATH', "tmp/docker.sock")
     parser = argparse.ArgumentParser(description='Synchronize running docker container IPs with host /etc/hosts file.')
-    parser.add_argument('socket', type=str, nargs="?", default="tmp/docker.sock", help='The docker socket to listen for docker events.')
-    parser.add_argument('file', type=str, nargs="?", default="/tmp/hosts", help='The /etc/hosts file to sync the containers with.')
+    parser.add_argument('socket', type=str, nargs="?", default=sockPath, help='The docker socket to listen for docker events.')
+    parser.add_argument('file', type=str, nargs="?", default=hostPath, help='The /etc/hosts file to sync the containers with.')
     return parser.parse_args()
 
 if __name__ == '__main__':


### PR DESCRIPTION
On some machines the hosts file could not be updated correctly.
For this reason, I have extended the hoster so that the path to the hosts file can be given via environment when starting the image.
Additionally I derived the base image directly from python:3.10.6-alpine3.16 to reduce the number of layers.