### PR TITLE
Handle container rename

### DIFF
--- a/hoster.py
+++ b/hoster.py
@@ -55,6 +55,13 @@ def main():
                 hosts.pop(container_id)
                 update_hosts_file()
 
+        if status=="rename":
+            container_id = e["id"]
+            if container_id in hosts:
+                container = get_container_data(dockerClient, container_id)
+                hosts[container_id] = container
+                update_hosts_file()
+
 
 def get_container_data(dockerClient, container_id):
     #extract all the info with the docker api


### PR DESCRIPTION
When renaming a container, the host file does not get updated.
This pull request fixes this issue.

I pushed a docker image containing this patch on Dockerhub if you need to test it : `aureleoules/docker-hoster`.